### PR TITLE
minor test improvements

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -16,7 +16,6 @@ linters:
   - gocyclo
   - gofmt
   - goimports
-  - golint
   - gosec
   - govet
   - lll
@@ -24,6 +23,7 @@ linters:
   - misspell
   - nakedret
   - prealloc
+  - revive
   - unconvert
   - unparam
   - unused
@@ -61,9 +61,6 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/org/project
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
   govet:
     # report about shadowed variables
     check-shadowing: true

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -14,7 +14,7 @@ import (
 func Context() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	sigCh := make(chan os.Signal, 5)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM) // nolint: govet
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigCh
 		cancel()


### PR DESCRIPTION
A follow up to #14 

This PR replaces a deprecated linter and also improves tests slightly by remediating a few linting issues instead of sweeping them under the rug.

This PR also fixes test cases where assertion functions took an `*httptest.ResponseRecorder` argument. `*http.Response`, which is more common and familiar type, is used instead. It should improve the overall readability of the tests.